### PR TITLE
feat: Use user-provided api keys

### DIFF
--- a/ai_wrappers.py
+++ b/ai_wrappers.py
@@ -19,6 +19,7 @@ genai_client = genai.Client(api_key=st.secrets["GEMINI_API_KEY"] if USE_STREAMLI
 claude_client = anthropic.Anthropic(api_key=st.secrets["CLAUDE_API_KEY"] if USE_STREAMLIT_SECRETS else CLAUDE_API_KEY)
 deepseek_client_api_key = st.secrets["DEEPSEEK_API_KEY"] if USE_STREAMLIT_SECRETS else DEEPSEEK_API_KEY
 
+
 def get_openai_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None) -> str:
     """
     Get a move from OpenAI's API based on the current board state and excluded moves.
@@ -129,6 +130,12 @@ def get_deepseek_move(board: chess.Board, sub_model: str, excluded_moves=None, d
             "Do not return any of those moves, and do not return any illegal moves.\n"
         )
 
+    override_key = st.session_state.get("override_deepseek", "")
+    if override_key:
+        api_key_to_use = override_key
+    else:
+        api_key_to_use = deepseek_client_api_key
+
     prompt = (
         f"You are a chess engine. It is {color_str}'s turn.\n"
         f"Given this FEN: {board.fen()}, return a legal best move in UCI format only.\n"
@@ -145,7 +152,7 @@ def get_deepseek_move(board: chess.Board, sub_model: str, excluded_moves=None, d
                 "messages": [{"role": "user", "content": prompt}],
                 "temperature": 0
             },
-            headers={"Authorization": f"Bearer {deepseek_client_api_key}"},
+            headers={"Authorization": f"Bearer {api_key_to_use}"},
             timeout=5
         )
         resp.raise_for_status()

--- a/ui.py
+++ b/ui.py
@@ -108,3 +108,41 @@ def render_main_ui():
         "random_fallback": random_fallback,
         "start_button_clicked": start_button_clicked
     }
+
+
+def render_api_key_inputs():
+    """
+    Renders text inputs in the sidebar for optional user-provided API keys.
+    Returns a dict with the user-provided keys, which may be empty strings if none entered.
+    :return: dict of API keys
+    """
+    user_keys = {"openai": "", "claude": "", "deepseek": "", "gemini": ""}
+
+    with st.sidebar.expander("Provide Your Own API Keys (Optional)", expanded=False):
+        user_keys["openai"] = st.text_input(
+            "OpenAI API Key",
+            value="",
+            type="password",
+            help="If left blank, fallback to config.py or st.secrets."
+        )
+        user_keys["claude"] = st.text_input(
+            "Claude API Key",
+            value="",
+            type="password",
+            help="If left blank, fallback to config.py or st.secrets."
+        )
+        user_keys["deepseek"] = st.text_input(
+            "DeepSeek API Key",
+            value="",
+            type="password",
+            help="If left blank, fallback to config.py or st.secrets."
+        )
+        user_keys["gemini"] = st.text_input(
+            "Gemini API Key",
+            value="",
+            type="password",
+            help="If left blank, fallback to config.py or st.secrets."
+        )
+
+    user_keys = {k: v.strip() for k, v in user_keys.items()}
+    return user_keys


### PR DESCRIPTION
- Allows the user to input new API keys in the UI
- Automatically recreates global claude_client and gemini_client with updated keys, or set the new api keys for openai and deepseek
- Ensures that new keys are used immediately for subsequent requests