### PR TITLE
Feat/include valid moves to prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ You can download the PGN file of the game for later analysis.
 └── README.md         # This file
 ```
 
+## Demo
+[Try it out here!](https://aichessbattle.streamlit.app)
+> [!NOTE]
+> Please use with  your own API keys, as the demo is rate-limited and may not work for everyone.
+> The demo is hosted on Streamlit Cloud and may be slow or unavailable at times.
+> If you want to run it locally, please follow the setup instructions above.
+
 ## Contributing
 Contributions are welcome! If you have suggestions or improvements, please open an issue or submit a pull request.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Edit the `config.py` file to include your API keys for the engines you want to u
 
 - Fallback: Decide if invalid moves should fallback to a random legal move or forfeit.
 
+- Toggle whether to include a list of legal moves in the prompt. (Increase accuracy, but potentially increase token usage.)
+
 - Choose a speed on the sidebar (x1 = normal, x2/x3/x4 = faster).
 
 - Click Start Game.

--- a/ai_wrappers.py
+++ b/ai_wrappers.py
@@ -22,32 +22,19 @@ deepseek_client = OpenAIClient(
 )
 
 
-def get_openai_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None) -> str:
+def get_openai_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None,
+                    include_valid_moves=False) -> str:
     """
     Get a move from OpenAI's API based on the current board state and excluded moves.
     :param board:  chess.Board object representing the current game state.
     :param sub_model:  The specific OpenAI model to use (e.g., "gpt-4o-mini").
     :param excluded_moves:  List of moves that are invalid or previously attempted.
     :param debug_log:  Function to log debug messages.
+    :param include_valid_moves:  Whether to include a list of valid moves in the prompt.
     :return:  The best move in UCI format as a string.
     """
-    if excluded_moves is None:
-        excluded_moves = []
-    color_str = "White" if board.turn == chess.WHITE else "Black"
 
-    exclusion_text = ""
-    if excluded_moves:
-        exclusion_text = (
-            f"Invalid or previously attempted moves that are NOT allowed:\n{excluded_moves}\n"
-            "Do not return any of those moves, and do not return any illegal moves.\n"
-        )
-
-    prompt = (
-        f"You are a chess engine. It is {color_str}'s turn.\n"
-        f"Given this FEN: {board.fen()}, return a legal best move in UCI format only.\n"
-        f"Do not return any explanations or additional text.\n"
-        f"{exclusion_text}"
-    )
+    prompt = build_chess_prompt(board, excluded_moves=excluded_moves, include_valid_moves=include_valid_moves)
 
     debug_log(f"[OpenAI/{sub_model}] Prompt:\n{prompt}")
 
@@ -61,32 +48,19 @@ def get_openai_move(board: chess.Board, sub_model: str, excluded_moves=None, deb
     return raw
 
 
-def get_claude_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None) -> str:
+def get_claude_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None,
+                    include_valid_moves=False) -> str:
     """
     Get a move from Claude's API based on the current board state and excluded moves.
     :param board:  chess.Board object representing the current game state.
     :param sub_model:  The specific Claude model to use (e.g., "claude-3-5-haiku-20241022").
     :param excluded_moves:  List of moves that are invalid or previously attempted.
     :param debug_log:  Function to log debug messages.
+    :param include_valid_moves:  Whether to include a list of valid moves in the prompt.
     :return:  The best move in UCI format as a string.
     """
-    if excluded_moves is None:
-        excluded_moves = []
-    color_str = "White" if board.turn == chess.WHITE else "Black"
 
-    exclusion_text = ""
-    if excluded_moves:
-        exclusion_text = (
-            f"Invalid or previously attempted moves that are NOT allowed:\n{excluded_moves}\n"
-            "Do not return any of those moves, and do not return any illegal moves.\n"
-        )
-
-    prompt = (
-        f"You are a chess engine. It is {color_str}'s turn.\n"
-        f"Given this FEN: {board.fen()}, return a legal best move in UCI format only.\n"
-        f"Do not return any explanations or additional text.\n"
-        f"{exclusion_text}"
-    )
+    prompt = build_chess_prompt(board, excluded_moves=excluded_moves, include_valid_moves=include_valid_moves)
 
     debug_log(f"[Claude/{sub_model}] Prompt:\n{prompt}")
 
@@ -103,32 +77,19 @@ def get_claude_move(board: chess.Board, sub_model: str, excluded_moves=None, deb
     return raw
 
 
-def get_deepseek_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None) -> str:
+def get_deepseek_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None,
+                      include_valid_moves=False) -> str:
     """
     Get a move from DeepSeek's API based on the current board state and excluded moves.
     :param board:  chess.Board object representing the current game state.
     :param sub_model:  The specific DeepSeek model to use (e.g., "deepseek-chat").
     :param excluded_moves:  List of moves that are invalid or previously attempted.
     :param debug_log:  Function to log debug messages.
+    :param include_valid_moves:  Whether to include a list of valid moves in the prompt.
     :return:  The best move in UCI format as a string.
     """
-    if excluded_moves is None:
-        excluded_moves = []
-    color_str = "White" if board.turn == chess.WHITE else "Black"
 
-    exclusion_text = ""
-    if excluded_moves:
-        exclusion_text = (
-            f"Invalid or previously attempted moves that are NOT allowed:\n{excluded_moves}\n"
-            "Do not return any of those moves, and do not return any illegal moves.\n"
-        )
-
-    prompt = (
-        f"You are a chess engine. It is {color_str}'s turn.\n"
-        f"Given this FEN: {board.fen()}, return a legal best move in UCI format only.\n"
-        f"Do not return any explanations or additional text.\n"
-        f"{exclusion_text}"
-    )
+    prompt = build_chess_prompt(board, excluded_moves=excluded_moves, include_valid_moves=include_valid_moves)
 
     debug_log(f"[DeepSeek/{sub_model}] Prompt:\n{prompt}")
 
@@ -142,32 +103,19 @@ def get_deepseek_move(board: chess.Board, sub_model: str, excluded_moves=None, d
     return raw
 
 
-def get_gemini_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None) -> str:
+def get_gemini_move(board: chess.Board, sub_model: str, excluded_moves=None, debug_log=lambda m: None,
+                    include_valid_moves=False) -> str:
     """
     Get a move from Gemini's API based on the current board state and excluded moves.
     :param board:  chess.Board object representing the current game state.
     :param sub_model:  The specific Gemini model to use (e.g., "gemini-2.0-flash").
     :param excluded_moves:  List of moves that are invalid or previously attempted.
     :param debug_log:  Function to log debug messages.
+    :param include_valid_moves:  Whether to include a list of valid moves in the prompt.
     :return:  The best move in UCI format as a string.
     """
-    if excluded_moves is None:
-        excluded_moves = []
-    color_str = "White" if board.turn == chess.WHITE else "Black"
 
-    exclusion_text = ""
-    if excluded_moves:
-        exclusion_text = (
-            f"Invalid or previously attempted moves that are NOT allowed:\n{excluded_moves}\n"
-            "Do not return any of those moves, and do not return any illegal moves.\n"
-        )
-
-    prompt = (
-        f"You are a chess engine. It is {color_str}'s turn.\n"
-        f"Given this FEN: {board.fen()}, return a legal best move in UCI format only.\n"
-        f"Do not return any explanations or additional text.\n"
-        f"{exclusion_text}"
-    )
+    prompt = build_chess_prompt(board, excluded_moves=excluded_moves, include_valid_moves=include_valid_moves)
 
     debug_log(f"[Gemini/{sub_model}] Prompt:\n{prompt}")
 
@@ -175,6 +123,51 @@ def get_gemini_move(board: chess.Board, sub_model: str, excluded_moves=None, deb
     raw = response.text.strip()
     debug_log(f"[Gemini/{sub_model}] Raw: {raw}")
     return raw
+
+
+def build_chess_prompt(
+        board: chess.Board,
+        excluded_moves: object = None,
+        include_valid_moves: bool = False
+) -> str:
+    """
+    Constructs a prompt for move generation based on the current board state,
+    excluded moves, and optionally includes the list of legal moves.
+
+    :param board: The current chess.Board object.
+    :param excluded_moves: List of moves to exclude from the suggestion.
+    :param include_valid_moves: Whether to append a list of legal moves to the prompt.
+    :return: The constructed prompt string.
+    """
+    if excluded_moves is None:
+        excluded_moves = []
+    color_str = "White" if board.turn == chess.WHITE else "Black"
+
+    exclusion_text = ""
+    valid_moves_str = ""
+    if excluded_moves:
+        exclusion_text = (
+            f"Invalid or previously attempted moves that are NOT allowed:\n{excluded_moves}\n"
+            "Do not return any of those moves, and do not return any illegal moves.\n"
+        )
+
+    if include_valid_moves:
+        # Append legal moves to the prompt
+        legal_moves = ", ".join(move.uci() for move in board.legal_moves)
+        valid_moves_str = (
+            f"Here is a list of legal moves: {legal_moves}\n"
+            "Please choose one of these moves.\n"
+        )
+
+    current_move_prompt = (
+        f"You are a chess engine. It is {color_str}'s turn.\n"
+        f"Given this FEN: {board.fen()}, return a legal best move in UCI format only.\n"
+        f"{valid_moves_str}"
+        "Do not return any explanations or additional text.\n"
+        f"{exclusion_text}"
+    )
+
+    return current_move_prompt
 
 
 ENGINE_FUNCTIONS = {

--- a/main.py
+++ b/main.py
@@ -134,6 +134,8 @@ if start_button_clicked:
             sub_model = black_sub_model
 
         start_time = time.time()
+
+        include_valid_moves = user_params["include_valid_moves"]
         move = safe_get_move(
             board=board,
             engine_func=engine_func,
@@ -141,7 +143,8 @@ if start_button_clicked:
             turn=turn,
             max_retries=3,
             random_fallback=random_fallback,
-            debug_log=debug_log
+            debug_log=debug_log,
+            include_valid_moves=include_valid_moves
         )
 
         # If no move => forfeit

--- a/move_logic.py
+++ b/move_logic.py
@@ -11,7 +11,8 @@ def safe_get_move(
         turn: str,
         max_retries=3,
         random_fallback=True,
-        debug_log=lambda m: None
+        debug_log=lambda m: None,
+        include_valid_moves=False
 ) -> Optional[chess.Move]:
     """
     Attempt to get a valid/legal move from the engine_func up to max_retries times.
@@ -24,12 +25,18 @@ def safe_get_move(
     :param max_retries: maximum number of attempts to get a valid move.
     :param random_fallback: whether to fallback to a random legal move if all attempts fail.
     :param debug_log: function to log debug messages.
+    :param include_valid_moves: whether to include a list of valid moves in the prompt.
     :return: a valid chess.Move object or None if no valid move is found.
     """
     excluded_moves = []
 
     for attempt in range(max_retries):
-        raw_move = engine_func(board, sub_model, excluded_moves=excluded_moves, debug_log=debug_log).strip()
+        raw_move = engine_func(board,
+                               sub_model,
+                               excluded_moves=excluded_moves,
+                               debug_log=debug_log,
+                               include_valid_moves=include_valid_moves
+                               ).strip()
         debug_log(f"{turn.title()} raw attempt #{attempt + 1} [model={sub_model}]: {raw_move}")
 
         # Try parse UCI

--- a/ui.py
+++ b/ui.py
@@ -90,9 +90,18 @@ def render_main_ui():
         increment = 0
 
     # Fallback or forfeit
-    random_fallback = st.checkbox(
+    random_fallback = st.toggle(
         "Fallback to random move if engine can't produce a valid move?",
         value=True
+    )
+    # Include a list valid moves in prompt
+    include_valid_moves = st.toggle(
+        "Include list of current legal moves in prompt to improve accuracy?",
+        value=False,
+        help="When enabled, "
+             "this option sends the current list of legal moves along with the board state to the model."
+             "This extra context can lead to more accurate move suggestions,"
+             "potentially decrease API calls, but will increase token usage."
     )
 
     start_button_clicked = st.button('Start Game')
@@ -106,6 +115,7 @@ def render_main_ui():
         "minutes": minutes,
         "increment": increment,
         "random_fallback": random_fallback,
+        "include_valid_moves": include_valid_moves,
         "start_button_clicked": start_button_clicked
     }
 

--- a/ui.py
+++ b/ui.py
@@ -99,9 +99,9 @@ def render_main_ui():
         "Include list of current legal moves in prompt to improve accuracy?",
         value=False,
         help="When enabled, "
-             "this option sends the current list of legal moves along with the board state to the model."
-             "This extra context can lead to more accurate move suggestions,"
-             "potentially decrease API calls, but will increase token usage."
+             "this option sends the current list of legal moves along with the board state to the model. "
+             "This extra context can lead to more accurate move suggestions. "
+             "It can potentially decrease API calls but will increase token usage."
     )
 
     start_button_clicked = st.button('Start Game')


### PR DESCRIPTION
- Introduced a UI toggle (with tooltip) that lets users include the current list of legal moves in the prompt.
- Refactored prompt building into a helper function used by all model wrapper functions to make the code more readable, reusable, and dynamic.
- This extra context can lead to more accurate move suggestions, potentially decrease API calls, but will increase token usage.
- update readme file